### PR TITLE
修復輸入串或候選、提示串中存在`%`符號時的錯誤

### DIFF
--- a/beta/schema/lua/yuhao/yuhao_embeded_cands.lua
+++ b/beta/schema/lua/yuhao/yuhao_embeded_cands.lua
@@ -62,6 +62,12 @@ local function render_comment(comment)
     return comment
 end
 
+-- 轉義符號 `%`, 因爲該符號是 string.gsub() 後兩個參數的轉義字符
+local function escape_percent(text)
+    text = string.gsub(text, "%%", "%%%%")
+    return text
+end
+
 -- 渲染單個候選項
 local function render_cand(seq, code, text, comment)
     local cand = ""
@@ -74,9 +80,9 @@ local function render_cand(seq, code, text, comment)
     -- 渲染提示串
     comment = render_comment(comment)
     cand = string.gsub(cand, "seq", index_indicators[seq])
-    cand = string.gsub(cand, "code", code)
-    cand = string.gsub(cand, "候選", text)
-    cand = string.gsub(cand, "comment", comment)
+    cand = string.gsub(cand, "code", escape_percent(code))
+    cand = string.gsub(cand, "候選", escape_percent(text))
+    cand = string.gsub(cand, "comment", escape_percent(comment))
     return cand
 end
 


### PR DESCRIPTION
當前預編輯串格式化過程中使用了 string.gsub() 函數，
其接受的二、三參數將`%`符號作爲轉義字符，導致：

- 打字時無法正常輸出符號`%`；
- 當候選字或提示中存在`%`符號時，無法正常輸出。

這個補丁在格式化前先將`%`轉換爲`%%`以避開轉義。