### PR TITLE
session-specific embeded cands switch

### DIFF
--- a/beta/schema/lua/yuhao/yuhao_embeded_cands.lua
+++ b/beta/schema/lua/yuhao/yuhao_embeded_cands.lua
@@ -32,16 +32,18 @@ local separator = ""
 
 -- 讀取 schema.yaml 開關設置:
 local option_name = "embeded_cands"
-local embeded_cands = nil
 
 function embeded_cands_filter.init(env)
+    -- 初始化局部表變量, 並裝入env
+    local embeded = {}
+    env.embeded = embeded
     local handler = function(ctx, name)
         -- 通知回調, 當改變選項值時更新暫存的值
         if name == option_name then
-            embeded_cands = ctx:get_option(name)
-            if embeded_cands == nil then
+            embeded.embeded_cands = ctx:get_option(name)
+            if embeded.embeded_cands == nil then
                 -- 當選項不存在時默認爲啓用狀態
-                embeded_cands = true
+                embeded.embeded_cands = true
             end
         end
     end
@@ -88,7 +90,7 @@ end
 
 -- 過濾器
 function embeded_cands_filter.func(input, env)
-    if not embeded_cands then
+    if not env.embeded.embeded_cands then
         for cand in input:iter() do
             yield(cand)
         end


### PR DESCRIPTION
舊有的「嵌入編碼開關」以 *lua* 模块局部變量方式定義，其狀態是所有 *librime* 會話共有的。因此當在一個會話中通過 *schema.switches* 改變其狀態後，其他會話中的啓用狀態也一併更新，然而其他會話中的 *schema.switches* 卻並未改變，這就導致 *schema* 與 *librime-lua* 記錄的狀態不一致，以及後續在不同會話中再改變該開關，會與預期表現不符。

本補丁將開關狀態改爲存放於當前會話的 *env* 中，做到 *lua* 開關狀態與 *schema* 實際開關狀態一致。這對全局使用同一 *librime* 會話的輸入平臺没有影響；對於獨立 *librime* 會話，則實現了各個會話使用不同的嵌入編碼設置。