### PR TITLE
允許在方案schema中配置嵌入候選格式

### DIFF
--- a/beta/schema/yuhao.custom.yaml
+++ b/beta/schema/yuhao.custom.yaml
@@ -15,3 +15,9 @@ patch:
   switches/@2/reset: 0 # [原始排序, 全碼後置]
   switches/@3/reset: 0 # [〇註解, 一重註解, 二重註解, 三重註解]
   switches/@4/reset: 0 # [普通候選, 嵌入候選]
+  embeded_cands/+:
+    # option_name: embeded_cands                         # 嵌入候選開關
+    # index_indicators: [ ¹, ², ³, ⁴, ⁵, ⁶, ⁷, ⁸, ⁹, ⁰ ] # 嵌入候選的序號顯示格式
+    # first_format: "${候選}${Comment}${Seq}"            # 首選的渲染格式
+    # next_format: "${候選}${Comment}${Seq}"             # 非首選的渲染格式
+    # separator: " "                                     # 候選之間的分隔符

--- a/beta/schema/yuhao.schema.yaml
+++ b/beta/schema/yuhao.schema.yaml
@@ -103,7 +103,7 @@ engine:
     - simplifier@traditionalize
     - simplifier@simplify
     - lua_filter@yuhao_chaifen
-    - lua_filter@yuhao_embeded_cands
+    - lua_filter@yuhao_embeded_cands@embeded_cands
     - uniquifier
 
 traditionalize:
@@ -199,6 +199,16 @@ reverse_lookup:
     - xform/([nl])v/$1ü/
     - xform/([nl])ue/$1üe/
     - xform/([jqxy])v/$1u/
+
+# 嵌入候選的顯示配置
+# 默認顯示效果爲:
+# 浩¹ 泃² 竘³
+embeded_cands:
+  option_name: embeded_cands                         # 嵌入候選開關
+  index_indicators: [ ¹, ², ³, ⁴, ⁵, ⁶, ⁷, ⁸, ⁹, ⁰ ] # 嵌入候選的序號顯示格式
+  first_format: "${候選}${Comment}${Seq}"            # 首選的渲染格式
+  next_format: "${候選}${Comment}${Seq}"             # 非首選的渲染格式
+  separator: " "                                     # 候選之間的分隔符
 
 punctuator:
   import_preset: default


### PR DESCRIPTION
更新 `yuhao_embeded_cands.lua`:

- `embeded_cands` 過濾器引入 *name_space* 支持;
- 根據 *name_space* 讀取對應的 *schema* 配置項, 當前可配置開關名稱、候選項顯示格式、分隔符;
- 調整格式化模板書寫, 减少歧義.