### PR TITLE
impl: custom lua macros | 實現: 自定義lua宏

### DIFF
--- a/beta/schema/lua/yuhao/yuhao_embeded_cands.lua
+++ b/beta/schema/lua/yuhao/yuhao_embeded_cands.lua
@@ -7,9 +7,6 @@
 -- 將要被返回的過濾器對象
 local embeded_cands_filter = {}
 
--- 導入外部模块變量
-local yuhao_switch_vars = require("yuhao.yuhao_switch").var
-
 --[[
 # xxx.schema.yaml
 switches:
@@ -142,7 +139,7 @@ end
 
 -- 過濾器
 function embeded_cands_filter.func(input, env)
-    if not env.option[env.config.option_name] and not yuhao_switch_vars.is_zhelp then
+    if not env.option[env.config.option_name] then
         for cand in input:iter() do
             yield(cand)
         end

--- a/beta/schema/lua/yuhao/yuhao_switch.lua
+++ b/beta/schema/lua/yuhao/yuhao_switch.lua
@@ -7,44 +7,33 @@
 local yuhao_switch_proc = {} -- 開關管理-processor
 local yuhao_switch_tr   = {} -- 開關管理-translator
 
--- 導出變量, 可在外部require模块以訪問
-local export_vars = {
-    is_zhelp = false -- 當前是否在zhelp模式下
-}
-
 -- ######## DEFINITION ########
 
 local kRejected = 0 -- 拒: 不作響應, 由操作系統做默認處理
 local kAccepted = 1 -- 收: 由rime響應該按鍵
 local kNoop     = 2 -- 無: 請下一個processor繼續看
 
-local cSpace  = string.byte(" ") -- 空格鍵
-local cReturn = 0xff0d           -- 回車鍵
+-- 宏類型枚舉
+local macro_types = {
+    tip    = "tip",
+    switch = "switch",
+    radio  = "radio",
+    shell  = "shell",
+    eval   = "eval",
+}
+
+-- 按命名空間歸類方案配置, 而不是按会話, 以减少内存佔用
+local namespaces = {}
+function namespaces:set_config(env, config)
+    namespaces[env.name_space] = namespaces[env.name_space] or {}
+    namespaces[env.name_space].config = config
+end
+function namespaces:config(env)
+    return namespaces[env.name_space] and namespaces[env.name_space].config
+end
 
 -- 候選序號標記
 local index_indicators = {"¹", "²", "³", "⁴", "⁵", "⁶", "⁷", "⁸", "⁹", "⁰"}
-
--- 選項開關列表
-local switch_options = {
-    -- 這部分是數組區, 寫入所有出現在候選處的開關名
-    "ascii_punct", "embeded_cands", "yuhao_single_char_only_for_full_code",
-    "traditionalization", "simplification",
-    "yuhao_chaifen",
-    -- 開關名對應的顯示文本
-    ascii_punct = "英符",
-    embeded_cands = "嵌入",
-    yuhao_single_char_only_for_full_code = "纯单",
-    traditionalization = "繁出",
-    simplification = "简出",
-    -- 單選開關使用嵌套的table描述
-    yuhao_chaifen = {
-        "yuhao_chaifen.off", "yuhao_chaifen.lv1", "yuhao_chaifen.lv2", "yuhao_chaifen.lv3",
-        ["yuhao_chaifen.off"] = "注解关",
-        ["yuhao_chaifen.lv1"] = "注解一",
-        ["yuhao_chaifen.lv2"] = "注解二",
-        ["yuhao_chaifen.lv3"] = "注解三",
-    },
-}
 
 -- ######## TOOLS ########
 
@@ -66,108 +55,412 @@ local function select_index(key, env)
     return index
 end
 
--- 開關狀態切換
-local function toggle_switch(env, ctx, option_name)
-    if not option_name then
-        return
-    end
-    local option = switch_options[option_name]
-    if type(option) == "string" then
-        -- 開關項
-        local current_value = ctx:get_option(option_name)
-        if current_value ~= nil then
-            ctx:set_option(option_name, not current_value)
+-- 設置開關狀態, 並更新保存的配置值
+local function set_option(env, ctx, option_name, value)
+    ctx:set_option(option_name, value)
+    if env.switcher then
+        -- 在支持的情況下, 更新保存的開關狀態
+        local swt = env.switcher
+        if swt:is_auto_save(option_name) and swt.user_config ~= nil then
+            swt.user_config:set_bool("var/option/" .. option_name, value)
         end
-    elseif type(option) == "table" then
-        -- 單選項
-        for i, op in ipairs(option) do
-            local value = ctx:get_option(op)
+    end
+end
+
+local _unix_supported
+-- 是否支持 Unix 命令
+local function unix_supported()
+    if _unix_supported == nil then
+        local res
+        _unix_supported, res = pcall(io.popen, "sleep 0")
+        if _unix_supported and res then
+            res:close()
+        end
+    end
+    return _unix_supported
+end
+
+-- 下文的 new_tip, new_switch, new_radio 等是目前已實現的宏類型
+-- 其返回類型統一定義爲:
+-- {
+--   type = "string",
+--   name = "string",
+--   display = function(self, ctx) ... end -> string
+--   trigger = function(self, ctx) ... end
+-- }
+-- 其中:
+-- type 字段僅起到標識作用
+-- name 字段亦非必須
+-- display() 爲該宏在候選欄中顯示的效果, 通常 name 非空時直接返回 name 的值
+-- trigger() 爲該宏被選中時, 上屏的文本内容, 返回空卽不上屏
+
+---提示語或快捷短語
+---顯示爲 name, 上屏爲 text
+---@param name string
+local function new_tip(name, text)
+    local tip = {
+        type = macro_types.tip,
+        name = name,
+        text = text,
+    }
+    function tip:display(ctx)
+        return #self.name ~= 0 and self.name or ""
+    end
+
+    function tip:trigger(env, ctx)
+        if #text ~= 0 then
+            env.engine:commit_text(text)
+        end
+        ctx:clear()
+    end
+
+    return tip
+end
+
+---開關
+---顯示 name 開關當前的狀態, 並在選中切換狀態
+---states 分别指定開關狀態爲 開 和 關 時的顯示效果
+---@param name string
+---@param states table
+local function new_switch(name, states)
+    local switch = {
+        type = macro_types.switch,
+        name = name,
+        states = states,
+    }
+    function switch:display(ctx)
+        local state = ""
+        local current_value = ctx:get_option(self.name)
+        if current_value then
+            state = self.states[2]
+        else
+            state = self.states[1]
+        end
+        return state
+    end
+
+    function switch:trigger(env, ctx)
+        local current_value = ctx:get_option(self.name)
+        if current_value ~= nil then
+            set_option(env, ctx, self.name, not current_value)
+        end
+    end
+
+    return switch
+end
+
+---單選
+---顯示一組 names 開關當前的狀態, 並在選中切換關閉當前開啓項, 並打開下一項
+---states 指定各組開關的 name 和當前開啓的開關時的顯示效果
+---@param states table
+local function new_radio(states)
+    local radio = {
+        type   = macro_types.radio,
+        states = states,
+    }
+    function radio:display(ctx)
+        local state = ""
+        for _, op in ipairs(self.states) do
+            local value = ctx:get_option(op.name)
             if value then
-                -- 關閉當前選項, 開啓下一選項
-                ctx:set_option(op, not value)
-                ctx:set_option(option[i%#option+1], value)
+                state = op.display
                 break
             end
         end
+        return state
     end
-end
 
--- 處理開關項調整
-local function handle_switch(env, ctx, idx)
-    -- 清理預輸入串, 达到調整後複位爲無輸入編碼的效果
-    -- ctx:clear()
-    toggle_switch(env, ctx, switch_options[idx+1])
-    return kAccepted
-end
-
--- 處理開關狀態展示候選
-local function handle_switch_display(env, ctx, seg, input)
-    local text_list = {}
-    for idx, option_name in ipairs(switch_options) do
-        local text = ""
-        local option = switch_options[option_name]
-        if type(option) == "string" then
-            -- 開關項, 渲染形如 "■選項¹"
-            local current_value = ctx:get_option(option_name)
-            if current_value then
-                text = text.."■"
-            else
-                text = text.."□"
+    function radio:trigger(env, ctx)
+        for i, op in ipairs(self.states) do
+            local value = ctx:get_option(op.name)
+            if value then
+                -- 關閉當前選項, 開啓下一選項
+                set_option(env, ctx, op.name, not value)
+                set_option(env, ctx, self.states[i % #self.states + 1].name, value)
+                return
             end
-            text = text..switch_options[option_name]..index_indicators[idx]
-        elseif type(option) == "table" then
-            -- 單選項, 渲染形如 "□■□狀態二"
-            local state = ""
-            for _, op in ipairs(option) do
-                local value = ctx:get_option(op)
-                if value then
-                    text = text.."■"
-                    state = option[op]
-                else
-                    text = text.."□"
+        end
+        -- 全都没開, 那就開一下第一個吧
+        set_option(env, ctx, self.states[1].name, true)
+    end
+
+    return radio
+end
+
+---Shell 命令, 僅支持 Linux/Mac 系統, 其他平臺可通過下文提供的 eval 宏自行擴展
+---name 非空時顯示其值, 爲空则顯示實時的 cmd 執行結果
+---cmd 爲待執行的命令内容
+---text 爲 true 時, 命令執行結果上屏, 否则僅執行
+---@param name string
+---@param cmd string
+---@param text boolean
+local function new_shell(name, cmd, text)
+    if not unix_supported() then
+        return nil
+    end
+
+    local template = "__macrowrapper() { %s ; }; __macrowrapper %s <<<''"
+    local function get_fd(args)
+        local cmdargs = {}
+        for _, arg in ipairs(args) do
+            table.insert(cmdargs, '"' .. arg .. '"')
+        end
+        return io.popen(string.format(template, cmd, table.concat(cmdargs, " ")), 'r')
+    end
+
+    local shell = {
+        type = macro_types.tip,
+        name = name,
+        text = text,
+    }
+
+    function shell:display(ctx, args)
+        return #self.name ~= 0 and self.name or self.text and get_fd(args):read('a')
+    end
+
+    function shell:trigger(env, ctx, args)
+        local fd = get_fd(args)
+        if self.text then
+            local t = fd:read('a')
+            if #t ~= 0 then
+                env.engine:commit_text(t)
+            end
+        end
+        fd:close()
+        ctx:clear()
+    end
+
+    return shell
+end
+
+---Evaluate 宏, 執行給定的 lua 表達式
+---name 非空時顯示其值, 否则顯示實時調用結果
+---expr 必須 return 一個值, 其類型可以是 string, function 或 table
+---返回 function 時, 該 function 接受一個 table 參數, 返回 string
+---返回 table 時, 該 table 成員方法 peek 和 eval 接受 self 和 table 參數, 返回 string, 分别指定顯示效果和上屏文本
+---@param name string
+---@param expr string
+local function new_eval(name, expr)
+    local f = load(expr)
+    if not f then
+        return nil
+    end
+
+    local eval = {
+        type = macro_types.eval,
+        name = name,
+        expr = f,
+    }
+
+    function eval:get_text(args, getter)
+        if type(self.expr) == "function" then
+            local res = self.expr(args)
+            if type(res) == "string" then
+                return res
+            elseif type(res) == "function" or type(res) == "table" then
+                self.expr = res
+            else
+                return ""
+            end
+        end
+
+        local res
+        if type(self.expr) == "function" then
+            res = self.expr(args)
+        elseif type(self.expr) == "table" then
+            local get_text = self.expr[getter]
+            res = type(get_text) == "function" and get_text(self.expr, args) or nil
+        end
+        return type(res) == "string" and res or ""
+    end
+
+    function eval:display(ctx, args)
+        if #self.name ~= 0 then
+            return self.name
+        else
+            return self:get_text(args, "peek")
+        end
+    end
+
+    function eval:trigger(env, ctx, args)
+        local text = self:get_text(args, "eval")
+        if #text ~= 0 then
+            env.engine:commit_text(text)
+        end
+        ctx:clear()
+    end
+
+    return eval
+end
+
+---@param input string
+---@param keylist table
+local function get_macro_args(input, keylist)
+    local sepset = ""
+    for key in pairs(keylist) do
+        -- only ascii keys
+        sepset = key >= 0x20 and key <= 0x7f and sepset .. string.char(key) or sepset
+    end
+    -- matches "[^/]"
+    local pattern = "[^" .. (#sepset ~= 0 and sepset or " ") .. "]*"
+    local args = {}
+    -- "echo/hello/world" -> "/hello", "/world"
+    for str in string.gmatch(input, "/" .. pattern) do
+        table.insert(args, string.sub(str, 2))
+    end
+    -- "echo/hello/world" -> "echo"
+    return string.match(input, pattern) or "", args
+end
+
+-- 從方案配置中讀取宏配置
+local function parse_conf_macro_list(env)
+    local macros = {}
+    local macro_map = env.engine.schema.config:get_map(env.name_space .. "/macros")
+    -- macros:
+    for _, key in ipairs(macro_map and macro_map:keys() or {}) do
+        local cands = {}
+        local cand_list = macro_map:get(key):get_list() or { size = 0 }
+        -- macros/help:
+        for i = 0, cand_list.size - 1 do
+            local key_map = cand_list:get_at(i):get_map()
+            -- macros/help[1]/type:
+            local type = key_map and key_map:has_key("type") and key_map:get_value("type"):get_string() or ""
+            if type == macro_types.tip then
+                -- {type: tip, name: foo}
+                if key_map:has_key("name") or key_map:has_key("text") then
+                    local name = key_map:has_key("name") and key_map:get_value("name"):get_string() or ""
+                    local text = key_map:has_key("text") and key_map:get_value("text"):get_string() or ""
+                    table.insert(cands, new_tip(name, text))
+                end
+            elseif type == macro_types.switch then
+                -- {type: switch, name: single_char, states: []}
+                if key_map:has_key("name") and key_map:has_key("states") then
+                    local name = key_map:get_value("name"):get_string()
+                    local states = {}
+                    local state_list = key_map:get("states"):get_list() or { size = 0 }
+                    for idx = 0, state_list.size - 1 do
+                        table.insert(states, state_list:get_value_at(idx):get_string())
+                    end
+                    if #name ~= 0 and #states > 1 then
+                        table.insert(cands, new_switch(name, states))
+                    end
+                end
+            elseif type == macro_types.radio then
+                -- {type: radio, names: [], states: []}
+                if key_map:has_key("names") and key_map:has_key("states") then
+                    local names, states = {}, {}
+                    local name_list = key_map:get("names"):get_list() or { size = 0 }
+                    for idx = 0, name_list.size - 1 do
+                        table.insert(names, name_list:get_value_at(idx):get_string())
+                    end
+                    local state_list = key_map:get("states"):get_list() or { size = 0 }
+                    for idx = 0, state_list.size - 1 do
+                        table.insert(states, state_list:get_value_at(idx):get_string())
+                    end
+                    if #names > 1 and #names == #states then
+                        local radio = {}
+                        for idx, name in ipairs(names) do
+                            if #name ~= 0 and #states[idx] ~= 0 then
+                                table.insert(radio, { name = name, display = states[idx] })
+                            end
+                        end
+                        table.insert(cands, new_radio(radio))
+                    end
+                end
+            elseif type == macro_types.shell then
+                -- {type: shell, name: foo, cmd: "echo hello"}
+                if key_map:has_key("cmd") and (key_map:has_key("name") or key_map:has_key("text")) then
+                    local cmd = key_map:get_value("cmd"):get_string()
+                    local name = key_map:has_key("name") and key_map:get_value("name"):get_string() or ""
+                    local text = key_map:has_key("text") and key_map:get_value("text"):get_bool() or false
+                    if #cmd ~= 0 and (#name ~= 0 or text) then
+                        table.insert(cands, new_shell(name, cmd, text))
+                    end
+                end
+            elseif type == macro_types.eval then
+                -- {type: eval, name: foo, expr: "os.date()"}
+                if key_map:has_key("expr") then
+                    local name = key_map:has_key("name") and key_map:get_value("name"):get_string() or ""
+                    local expr = key_map:get_value("expr"):get_string()
+                    if #expr ~= 0 then
+                        table.insert(cands, new_eval(name, expr))
+                    end
                 end
             end
-            text = text..state..index_indicators[idx]
         end
-        table.insert(text_list, text)
+        if #cands ~= 0 then
+            macros[key] = cands
+        end
     end
-    -- 避免選項翻頁, 直接渲染到首選提示中
-    local cand = Candidate("switch", seg.start, seg._end, "", table.concat(text_list, " "))
-    yield(cand)
+    return macros
+end
+
+-- 從方案配置中讀取功能鍵配置
+local function parse_conf_funckeys(env)
+    local funckeys = {
+        macro = {},
+    }
+    local keys_map = env.engine.schema.config:get_map(env.name_space .. "/funckeys")
+    for _, key in ipairs(keys_map and keys_map:keys() or {}) do
+        if funckeys[key] then
+            local char_list = keys_map:get(key):get_list() or { size = 0 }
+            for i = 0, char_list.size - 1 do
+                funckeys[key][char_list:get_value_at(i):get_int() or 0] = true
+            end
+        end
+    end
+    return funckeys
 end
 
 -- ######## PROCESSOR ########
 
+local function proc_handle_macros(env, ctx, input, idx)
+    local name, args = get_macro_args(input, namespaces:config(env).funckeys.macro)
+    local macro = namespaces:config(env).macros[name]
+    if macro then
+        if macro[idx] then
+            macro[idx]:trigger(env, ctx, args)
+        end
+        return kAccepted
+    end
+    return kNoop
+end
+
 function yuhao_switch_proc.init(env)
+    if Switcher then
+        env.switcher = Switcher(env.engine)
+    end
+
+    -- 讀取配置項
+    if not namespaces:config(env) then
+        local config = {}
+        config.macros = parse_conf_macro_list(env)
+        config.funckeys = parse_conf_funckeys(env)
+        namespaces:set_config(env, config)
+    end
 end
 
 function yuhao_switch_proc.func(key_event, env)
-    if key_event:release() or key_event:alt() then
-        -- 不是我關注的鍵按下事件
-        return kNoop
-    end
-
     local ctx = env.engine.context
-    if #ctx.input == 0 then
-        -- 當前無輸入, 略之
+    if #ctx.input == 0 or key_event:release() or key_event:alt() then
+        -- 當前無輸入, 或不是我關注的鍵按下事件, 棄之
         return kNoop
     end
 
     local ch = key_event.keycode
-    if ctx.input == "zhelp" then
-        if ch == 0xff0d then
-            ctx:clear()
-            return kAccepted
-        end
-        -- 開關管理
+    local funckeys = namespaces:config(env).funckeys
+    if funckeys.macro[string.byte(string.sub(ctx.input, 1, 1))] then
+        -- 當前輸入串以 funckeys/macro 定義的鍵集合開頭
         local idx = select_index(key_event, env)
-        if ch == cSpace or ch == cReturn then
-            -- 空格或回車退出開關管理模式
-            ctx:clear()
+        if idx >= 0 then
+            -- 選中宏候選
+            return proc_handle_macros(env, ctx, string.sub(ctx.input, 2), idx + 1)
+        elseif funckeys.macro[ch] then
+            -- 宏候選分隔符
+            ctx:push_input(string.char(ch))
             return kAccepted
-        elseif idx >= 0 then
-            return handle_switch(env, ctx, idx)
         else
+            -- 假裝無事發生
             return kNoop
         end
     end
@@ -180,18 +473,35 @@ end
 
 -- ######## TRANSLATOR ########
 
+-- 處理宏
+local function tr_handle_macros(env, ctx, seg, input)
+    local name, args = get_macro_args(input, namespaces:config(env).funckeys.macro)
+    local macro = namespaces:config(env).macros[name]
+    if macro then
+        local text_list = {}
+        for i, m in ipairs(macro) do
+            table.insert(text_list, m:display(ctx, args) .. index_indicators[i])
+        end
+        local cand = Candidate("macro", seg.start, seg._end, "", table.concat(text_list, " "))
+        yield(cand)
+    end
+end
+
 function yuhao_switch_tr.init(env)
+    if not namespaces:config(env) then
+        local config = {}
+        config.macros = parse_conf_macro_list(env)
+        config.funckeys = parse_conf_funckeys(env)
+        namespaces:set_config(env, config)
+    end
 end
 
 function yuhao_switch_tr.func(input, seg, env)
     local ctx = env.engine.context
-    if input == "zhelp" then
-        export_vars.is_zhelp = true
-        -- 快捷開關
-        handle_switch_display(env, ctx, seg, input)
+    local funckeys = namespaces:config(env).funckeys
+    if funckeys.macro[string.byte(string.sub(ctx.input, 1, 1))] then
+        tr_handle_macros(env, ctx, seg, string.sub(input, 2))
         return
-    else
-        export_vars.is_zhelp = false
     end
 end
 
@@ -203,5 +513,4 @@ end
 return {
     proc = yuhao_switch_proc, -- 開關管理-processor
     tr   = yuhao_switch_tr,   -- 開關管理-translator
-    var  = export_vars,       -- 導出本地變量
 }

--- a/beta/schema/yuhao.custom.yaml
+++ b/beta/schema/yuhao.custom.yaml
@@ -21,3 +21,113 @@ patch:
     # first_format: "${候選}${Comment}${Seq}"            # 首選的渲染格式
     # next_format: "${候選}${Comment}${Seq}"             # 非首選的渲染格式
     # separator: " "                                     # 候選之間的分隔符
+  recognizer/patterns/+:
+    # 配合自定義宏, 允許以下宏使用 / 鍵追加參數
+    macros: "^/(calc|echo|len)(/[a-z]*)*$"
+  yuhao_macro/macros/+:
+    # 自定義宏
+    # 先为宏命名, 如 *mymacro*, 则將其添加到 *macros* 下,
+    # 再在 *mymacro* 下添加若干候選宏, 每個候選宏都需指定一個 *type*.
+    # 当前支持的宏類型:
+    # *tip*:    {type: tip,    name: display,     text: commit},                     其中 *text* 为可選項.
+    # *switch*: {type: switch, name: switch_name, states: [off_display,on_display]}, 類似 *schema/switches*.
+    # *radio*:  {type: radio,  names: [s1,s2,s3], states: [d1,d2,d3]},               類似 *schema/switches* 之 *options*.
+    # *shell*:  {type: shell,  name: display,     cmd: shell_cmd,   text: true},     僅支持 Linux/Mac, 不支持 Windows, 亦不支持移動平臺. 選中时執行 *shell_cmd* 命令, *text* 可選, 設为 true 時收集並提交命令輸出.
+    # *eval*:   {type: eval,   name: display,     expr: "local a='bar'; return a"},  其中 *name* 为可選項, *expr* 必須是個 *return* 語句, 蓋 *lua* 將以 "function() <expr> end" 方式組裝函數並調用.
+    # 下面給出一些示例
+    repo:
+      # 此爲 shell 宏演示, 僅在 Linux/Mac 下可用
+      # 又因使用 xdg-open 命令, 故只有 Linux 下可成功調用. Mac 下可將 xdg-open 改爲 open
+      - type: tip
+        name: 訪問倉庫
+      - type: shell
+        name: ⚛宇浩
+        cmd: xdg-open https://github.com/forfudan/yuhao
+    user:
+      # 這是調用 shell 命令, 在 Linux/Mac/Android 下可用
+      # 當 text 指定爲 true 時, 將命令執行的結果上屏
+      - type: shell
+        name: ☘用户名
+        cmd: echo -n $(whoami)
+        text: true
+    echo:
+      # 含參 shell 命令示例, 參数會經由簡易 wrapper 函數傳遞給命令
+      # __macrowrapper() { CMD; }; __macrowrapper ARGS <<<''
+      # 對於 /echo/eng/hello, 其最終執行的 shell 命令爲 echo eng hello
+      # 當 name 字段爲空時, 命令是實時調用的, 卽每輸入一個字符, 都執行一次命令, 請留意可能誤致過多的命令調用
+      # 注意需要配合 recognizer
+      - type: shell
+        cmd: echo -n "$@"
+        text: true
+      - type: shell
+        name: info
+        cmd: zenity --info --text "$(echo -n $@)"
+    quick:
+      # 這裏演示將 tip 用作快捷短語
+      # 當 text 爲空時, 僅作爲提示, 若非空則選中時上屏 text 内容
+      - type: tip
+        name: 快捷短語
+      - type: tip
+        name: ☎郵箱
+        text: 1234567890@qq.com
+      - type: tip
+        name: ☏群號
+        text: "735728797"
+    foo:
+      # lua 語句: 返回一個字符串
+      # 示例在 yuhao.schema.yaml/yuhao_macro/date 和 -/time 中也已給出
+      - type: eval
+        expr: return "bar"
+    len:
+      # lua 函數
+      # 示例: 返回一個 function(args) ... end -> string 函數
+      # 對於 /len/hello/world, 其 args 值爲 {"hello", "world"}
+      # 注意需要配合 recognizer
+      - type: eval
+        expr: return
+          function(args)
+            local lens = {}
+            for _, str in ipairs(args) do
+              table.insert(lens, string.len(str))
+            end
+            return table.concat(lens, ",")
+          end
+    calc:
+      # lua 對象, 須返回一個 {
+      #   peek = function(self, args) ... end -> string, -- 當 name 爲空時, 候選攔顯示此值
+      #   eval = function(self, args) ... end -> string, -- 當按下空格或選重鍵後, 上屏此值
+      # } 對象
+      # 示例: 簡易計算器
+      # qwertyuiop => 1234567890
+      # hjkl => *-+/
+      # x => *
+      # s(square) => ^
+      # d(dot) => .
+      # m(mod) => %
+      # a(remainder) => //
+      - type: eval
+        expr: >
+          local nums = {q='1',w='2',e='3',r='4',t='5',y='6',u='7',i='8',o='9',p='0'}
+          local signs = {h='*',j='-',k='+',l='/',s='^',d='.',m='%',x='*',a='//'}
+          setmetatable(signs, { __index = function() return "+" end })
+          local t = {
+            nums = nums,
+            signs = signs,
+          }
+          function t:calc(args, peek_only)
+            if #args == 0 then return "" end
+            local res = {}
+            for _, expr in ipairs(args) do
+              expr = string.gsub(string.gsub(expr, "[qwertyuiop]", self.nums), "[^0-9]+", self.signs)
+              local eval = load("return " .. expr)
+              table.insert(res, (peek_only and expr .. "=" or "") .. (eval and eval() or "?"))
+            end
+            return table.concat(res, ",")
+          end
+          function t:peek(args)
+            return self:calc(args, true)
+          end
+          function t:eval(args)
+            return self:calc(args, false)
+          end
+          return t

--- a/beta/schema/yuhao.schema.yaml
+++ b/beta/schema/yuhao.schema.yaml
@@ -69,7 +69,7 @@ switches:
 
 engine:
   processors:
-    - lua_processor@yuhao_switch_proc
+    - lua_processor@yuhao_switch_proc@yuhao_macro
     - ascii_composer
     - recognizer
     - lua_processor@yuhao_chaifen_processor
@@ -94,7 +94,7 @@ engine:
     - table_translator
     - lua_translator@yuhao_helper # 幫助文檔
     - "table_translator@zaoci" # 用户造詞
-    - lua_translator@yuhao_switch_tr
+    - lua_translator@yuhao_switch_tr@yuhao_macro
   filters:
     - lua_filter@yuhao_single_char_only_for_full_code
     - lua_filter@yuhao_char_first
@@ -210,6 +210,36 @@ embeded_cands:
   next_format: "${候選}${Comment}${Seq}"             # 非首選的渲染格式
   separator: " "                                     # 候選之間的分隔符
 
+# 自定義宏
+yuhao_macro:
+  funckeys:
+    macro: [ 0x2f ] # 當輸入串以 "/" 開頭時, 認爲是宏調用
+  macros:
+    help:
+      - { type: tip, name: ❖配置中心 }
+      - { type: switch, name: embeded_cands, states: [ ☐嵌入, ☑嵌入 ] }
+      - { type: switch, name: yuhao_single_char_only_for_full_code, states: [ ☐字詞, ☑純單 ] }
+      - { type: radio, names: [ yuhao_chaifen.off, yuhao_chaifen.lv1, yuhao_chaifen.lv2, yuhao_chaifen.lv3 ], states: [ ☐☐☐註解, ☑☐☐註解, ☐☑☐註解, ☐☐☑註解 ] }
+      - { type: switch, name: traditionalization, states: [ ☐簡保持, ☑簡轉繁 ] }
+      - { type: switch, name: simplification, states: [ ☐繁保持, ☑繁轉簡 ] }
+    date:
+      - { type: eval, name: ☀日期, expr: return os.date("%Y-%m-%d") }
+      - { type: eval, name: ⛅年月日, expr: return os.date("%Y年%m月%d日") }
+    time:
+      - { type: eval, name: ⌚時間, expr: return os.date("%H:%M:%S") }
+      - { type: eval, name: Ⓣ時間, expr: return os.date("%Y%m%d%H%M") }
+      - { type: eval, name: Ⓢ時間戳, expr: return tostring(os.time()) }
+    char:
+      - { type: switch, name: yuhao_single_char_only_for_full_code, states: [ ☐字詞, ☑純單 ] }
+    div:
+      - { type: radio, names: [ yuhao_chaifen.off, yuhao_chaifen.lv1, yuhao_chaifen.lv2, yuhao_chaifen.lv3 ], states: [ ☐☐☐註解, ☑☐☐註解, ☐☑☐註解, ☐☐☑註解 ] }
+    embed:
+      - { type: switch, name: embeded_cands, states: [ ☐嵌入, ☑嵌入 ] }
+    trad:
+      - { type: switch, name: traditionalization, states: [ ☐不轉換, ☑簡轉繁 ] }
+    simp:
+      - { type: switch, name: simplification, states: [ ☐不轉換, ☑繁轉簡 ] }
+
 punctuator:
   import_preset: symbols
   half_shape:
@@ -257,6 +287,7 @@ recognizer:
     uppercase: "^(?![`;]).*[A-Z][-_+.'0-9A-Za-z]*$"
     reverse_lookup: "^z([a-z]+?)*$"
     zaoci: "^[a-y]*`[a-y`]*$"
+    macro: "^/[a-z]*$"
 
 style:
   horizontal: false

--- a/beta/schema/yuhao_tc.custom.yaml
+++ b/beta/schema/yuhao_tc.custom.yaml
@@ -21,3 +21,113 @@ patch:
     # first_format: "${候選}${Comment}${Seq}"            # 首選的渲染格式
     # next_format: "${候選}${Comment}${Seq}"             # 非首選的渲染格式
     # separator: " "                                     # 候選之間的分隔符
+  recognizer/patterns/+:
+    # 配合自定義宏, 允許以下宏使用 / 鍵追加參數
+    macros: "^/(calc|echo|len)(/[a-z]*)*$"
+  yuhao_macro/macros/+:
+    # 自定義宏
+    # 先为宏命名, 如 *mymacro*, 则將其添加到 *macros* 下,
+    # 再在 *mymacro* 下添加若干候選宏, 每個候選宏都需指定一個 *type*.
+    # 当前支持的宏類型:
+    # *tip*:    {type: tip,    name: display,     text: commit},                     其中 *text* 为可選項.
+    # *switch*: {type: switch, name: switch_name, states: [off_display,on_display]}, 類似 *schema/switches*.
+    # *radio*:  {type: radio,  names: [s1,s2,s3], states: [d1,d2,d3]},               類似 *schema/switches* 之 *options*.
+    # *shell*:  {type: shell,  name: display,     cmd: shell_cmd,   text: true},     僅支持 Linux/Mac, 不支持 Windows, 亦不支持移動平臺. 選中时執行 *shell_cmd* 命令, *text* 可選, 設为 true 時收集並提交命令輸出.
+    # *eval*:   {type: eval,   name: display,     expr: "local a='bar'; return a"},  其中 *name* 为可選項, *expr* 必須是個 *return* 語句, 蓋 *lua* 將以 "function() <expr> end" 方式組裝函數並調用.
+    # 下面給出一些示例
+    repo:
+      # 此爲 shell 宏演示, 僅在 Linux/Mac 下可用
+      # 又因使用 xdg-open 命令, 故只有 Linux 下可成功調用. Mac 下可將 xdg-open 改爲 open
+      - type: tip
+        name: 訪問倉庫
+      - type: shell
+        name: ⚛宇浩
+        cmd: xdg-open https://github.com/forfudan/yuhao
+    user:
+      # 這是調用 shell 命令, 在 Linux/Mac/Android 下可用
+      # 當 text 指定爲 true 時, 將命令執行的結果上屏
+      - type: shell
+        name: ☘用户名
+        cmd: echo -n $(whoami)
+        text: true
+    echo:
+      # 含參 shell 命令示例, 參数會經由簡易 wrapper 函數傳遞給命令
+      # __macrowrapper() { CMD; }; __macrowrapper ARGS <<<''
+      # 對於 /echo/eng/hello, 其最終執行的 shell 命令爲 echo eng hello
+      # 當 name 字段爲空時, 命令是實時調用的, 卽每輸入一個字符, 都執行一次命令, 請留意可能誤致過多的命令調用
+      # 注意需要配合 recognizer
+      - type: shell
+        cmd: echo -n "$@"
+        text: true
+      - type: shell
+        name: info
+        cmd: zenity --info --text "$(echo -n $@)"
+    quick:
+      # 這裏演示將 tip 用作快捷短語
+      # 當 text 爲空時, 僅作爲提示, 若非空則選中時上屏 text 内容
+      - type: tip
+        name: 快捷短語
+      - type: tip
+        name: ☎郵箱
+        text: 1234567890@qq.com
+      - type: tip
+        name: ☏群號
+        text: "735728797"
+    foo:
+      # lua 語句: 返回一個字符串
+      # 示例在 yuhao.schema.yaml/yuhao_macro/date 和 -/time 中也已給出
+      - type: eval
+        expr: return "bar"
+    len:
+      # lua 函數
+      # 示例: 返回一個 function(args) ... end -> string 函數
+      # 對於 /len/hello/world, 其 args 值爲 {"hello", "world"}
+      # 注意需要配合 recognizer
+      - type: eval
+        expr: return
+          function(args)
+            local lens = {}
+            for _, str in ipairs(args) do
+              table.insert(lens, string.len(str))
+            end
+            return table.concat(lens, ",")
+          end
+    calc:
+      # lua 對象, 須返回一個 {
+      #   peek = function(self, args) ... end -> string, -- 當 name 爲空時, 候選攔顯示此值
+      #   eval = function(self, args) ... end -> string, -- 當按下空格或選重鍵後, 上屏此值
+      # } 對象
+      # 示例: 簡易計算器
+      # qwertyuiop => 1234567890
+      # hjkl => *-+/
+      # x => *
+      # s(square) => ^
+      # d(dot) => .
+      # m(mod) => %
+      # a(remainder) => //
+      - type: eval
+        expr: >
+          local nums = {q='1',w='2',e='3',r='4',t='5',y='6',u='7',i='8',o='9',p='0'}
+          local signs = {h='*',j='-',k='+',l='/',s='^',d='.',m='%',x='*',a='//'}
+          setmetatable(signs, { __index = function() return "+" end })
+          local t = {
+            nums = nums,
+            signs = signs,
+          }
+          function t:calc(args, peek_only)
+            if #args == 0 then return "" end
+            local res = {}
+            for _, expr in ipairs(args) do
+              expr = string.gsub(string.gsub(expr, "[qwertyuiop]", self.nums), "[^0-9]+", self.signs)
+              local eval = load("return " .. expr)
+              table.insert(res, (peek_only and expr .. "=" or "") .. (eval and eval() or "?"))
+            end
+            return table.concat(res, ",")
+          end
+          function t:peek(args)
+            return self:calc(args, true)
+          end
+          function t:eval(args)
+            return self:calc(args, false)
+          end
+          return t

--- a/beta/schema/yuhao_tc.schema.yaml
+++ b/beta/schema/yuhao_tc.schema.yaml
@@ -63,7 +63,7 @@ switches:
 
 engine:
   processors:
-    - lua_processor@yuhao_switch_proc
+    - lua_processor@yuhao_switch_proc@yuhao_macro
     - ascii_composer
     - recognizer
     - lua_processor@yuhao_chaifen_processor
@@ -88,7 +88,7 @@ engine:
     - table_translator
     - lua_translator@yuhao_helper # 幫助文檔
     - "table_translator@zaoci" # 用户造詞
-    - lua_translator@yuhao_switch_tr
+    - lua_translator@yuhao_switch_tr@yuhao_macro
   filters:
     - lua_filter@yuhao_single_char_only_for_full_code
     - lua_filter@yuhao_char_first
@@ -194,6 +194,36 @@ embeded_cands:
   next_format: "${候選}${Comment}${Seq}"             # 非首選的渲染格式
   separator: " "                                     # 候選之間的分隔符
 
+# 自定義宏
+yuhao_macro:
+  funckeys:
+    macro: [ 0x2f ] # 當輸入串以 "/" 開頭時, 認爲是宏調用
+  macros:
+    help:
+      - { type: tip, name: ❖配置中心 }
+      - { type: switch, name: embeded_cands, states: [ ☐嵌入, ☑嵌入 ] }
+      - { type: switch, name: yuhao_single_char_only_for_full_code, states: [ ☐字詞, ☑純單 ] }
+      - { type: radio, names: [ yuhao_chaifen.off, yuhao_chaifen.lv1, yuhao_chaifen.lv2, yuhao_chaifen.lv3 ], states: [ ☐☐☐註解, ☑☐☐註解, ☐☑☐註解, ☐☐☑註解 ] }
+      - { type: switch, name: traditionalization, states: [ ☐簡保持, ☑簡轉繁 ] }
+      - { type: switch, name: simplification, states: [ ☐繁保持, ☑繁轉簡 ] }
+    date:
+      - { type: eval, name: ☀日期, expr: return os.date("%Y-%m-%d") }
+      - { type: eval, name: ⛅年月日, expr: return os.date("%Y年%m月%d日") }
+    time:
+      - { type: eval, name: ⌚時間, expr: return os.date("%H:%M:%S") }
+      - { type: eval, name: Ⓣ時間, expr: return os.date("%Y%m%d%H%M") }
+      - { type: eval, name: Ⓢ時間戳, expr: return tostring(os.time()) }
+    char:
+      - { type: switch, name: yuhao_single_char_only_for_full_code, states: [ ☐字詞, ☑純單 ] }
+    div:
+      - { type: radio, names: [ yuhao_chaifen.off, yuhao_chaifen.lv1, yuhao_chaifen.lv2, yuhao_chaifen.lv3 ], states: [ ☐☐☐註解, ☑☐☐註解, ☐☑☐註解, ☐☐☑註解 ] }
+    embed:
+      - { type: switch, name: embeded_cands, states: [ ☐嵌入, ☑嵌入 ] }
+    trad:
+      - { type: switch, name: traditionalization, states: [ ☐不轉換, ☑簡轉繁 ] }
+    simp:
+      - { type: switch, name: simplification, states: [ ☐不轉換, ☑繁轉簡 ] }
+
 punctuator:
   import_preset: symbols
   half_shape:
@@ -240,6 +270,7 @@ recognizer:
     uppercase: "^(?![`;]).*[A-Z][-_+.'0-9A-Za-z]*$"
     reverse_lookup: "^z([a-z]+?)*$"
     zaoci: "^[a-y]*`[a-y`]*$"
+    macro: "^/[a-z]*$"
 
 style:
   horizontal: false

--- a/beta/schema/yuhao_tw.custom.yaml
+++ b/beta/schema/yuhao_tw.custom.yaml
@@ -21,3 +21,113 @@ patch:
     # first_format: "${候選}${Comment}${Seq}"            # 首選的渲染格式
     # next_format: "${候選}${Comment}${Seq}"             # 非首選的渲染格式
     # separator: " "                                     # 候選之間的分隔符
+  recognizer/patterns/+:
+    # 配合自定義宏, 允許以下宏使用 / 鍵追加參數
+    macros: "^/(calc|echo|len)(/[a-z]*)*$"
+  yuhao_macro/macros/+:
+    # 自定義宏
+    # 先为宏命名, 如 *mymacro*, 则將其添加到 *macros* 下,
+    # 再在 *mymacro* 下添加若干候選宏, 每個候選宏都需指定一個 *type*.
+    # 当前支持的宏類型:
+    # *tip*:    {type: tip,    name: display,     text: commit},                     其中 *text* 为可選項.
+    # *switch*: {type: switch, name: switch_name, states: [off_display,on_display]}, 類似 *schema/switches*.
+    # *radio*:  {type: radio,  names: [s1,s2,s3], states: [d1,d2,d3]},               類似 *schema/switches* 之 *options*.
+    # *shell*:  {type: shell,  name: display,     cmd: shell_cmd,   text: true},     僅支持 Linux/Mac, 不支持 Windows, 亦不支持移動平臺. 選中时執行 *shell_cmd* 命令, *text* 可選, 設为 true 時收集並提交命令輸出.
+    # *eval*:   {type: eval,   name: display,     expr: "local a='bar'; return a"},  其中 *name* 为可選項, *expr* 必須是個 *return* 語句, 蓋 *lua* 將以 "function() <expr> end" 方式組裝函數並調用.
+    # 下面給出一些示例
+    repo:
+      # 此爲 shell 宏演示, 僅在 Linux/Mac 下可用
+      # 又因使用 xdg-open 命令, 故只有 Linux 下可成功調用. Mac 下可將 xdg-open 改爲 open
+      - type: tip
+        name: 訪問倉庫
+      - type: shell
+        name: ⚛宇浩
+        cmd: xdg-open https://github.com/forfudan/yuhao
+    user:
+      # 這是調用 shell 命令, 在 Linux/Mac/Android 下可用
+      # 當 text 指定爲 true 時, 將命令執行的結果上屏
+      - type: shell
+        name: ☘用户名
+        cmd: echo -n $(whoami)
+        text: true
+    echo:
+      # 含參 shell 命令示例, 參数會經由簡易 wrapper 函數傳遞給命令
+      # __macrowrapper() { CMD; }; __macrowrapper ARGS <<<''
+      # 對於 /echo/eng/hello, 其最終執行的 shell 命令爲 echo eng hello
+      # 當 name 字段爲空時, 命令是實時調用的, 卽每輸入一個字符, 都執行一次命令, 請留意可能誤致過多的命令調用
+      # 注意需要配合 recognizer
+      - type: shell
+        cmd: echo -n "$@"
+        text: true
+      - type: shell
+        name: info
+        cmd: zenity --info --text "$(echo -n $@)"
+    quick:
+      # 這裏演示將 tip 用作快捷短語
+      # 當 text 爲空時, 僅作爲提示, 若非空則選中時上屏 text 内容
+      - type: tip
+        name: 快捷短語
+      - type: tip
+        name: ☎郵箱
+        text: 1234567890@qq.com
+      - type: tip
+        name: ☏群號
+        text: "735728797"
+    foo:
+      # lua 語句: 返回一個字符串
+      # 示例在 yuhao.schema.yaml/yuhao_macro/date 和 -/time 中也已給出
+      - type: eval
+        expr: return "bar"
+    len:
+      # lua 函數
+      # 示例: 返回一個 function(args) ... end -> string 函數
+      # 對於 /len/hello/world, 其 args 值爲 {"hello", "world"}
+      # 注意需要配合 recognizer
+      - type: eval
+        expr: return
+          function(args)
+            local lens = {}
+            for _, str in ipairs(args) do
+              table.insert(lens, string.len(str))
+            end
+            return table.concat(lens, ",")
+          end
+    calc:
+      # lua 對象, 須返回一個 {
+      #   peek = function(self, args) ... end -> string, -- 當 name 爲空時, 候選攔顯示此值
+      #   eval = function(self, args) ... end -> string, -- 當按下空格或選重鍵後, 上屏此值
+      # } 對象
+      # 示例: 簡易計算器
+      # qwertyuiop => 1234567890
+      # hjkl => *-+/
+      # x => *
+      # s(square) => ^
+      # d(dot) => .
+      # m(mod) => %
+      # a(remainder) => //
+      - type: eval
+        expr: >
+          local nums = {q='1',w='2',e='3',r='4',t='5',y='6',u='7',i='8',o='9',p='0'}
+          local signs = {h='*',j='-',k='+',l='/',s='^',d='.',m='%',x='*',a='//'}
+          setmetatable(signs, { __index = function() return "+" end })
+          local t = {
+            nums = nums,
+            signs = signs,
+          }
+          function t:calc(args, peek_only)
+            if #args == 0 then return "" end
+            local res = {}
+            for _, expr in ipairs(args) do
+              expr = string.gsub(string.gsub(expr, "[qwertyuiop]", self.nums), "[^0-9]+", self.signs)
+              local eval = load("return " .. expr)
+              table.insert(res, (peek_only and expr .. "=" or "") .. (eval and eval() or "?"))
+            end
+            return table.concat(res, ",")
+          end
+          function t:peek(args)
+            return self:calc(args, true)
+          end
+          function t:eval(args)
+            return self:calc(args, false)
+          end
+          return t

--- a/beta/schema/yuhao_tw.schema.yaml
+++ b/beta/schema/yuhao_tw.schema.yaml
@@ -61,7 +61,7 @@ switches:
 
 engine:
   processors:
-    - lua_processor@yuhao_switch_proc
+    - lua_processor@yuhao_switch_proc@yuhao_macro
     - ascii_composer
     - recognizer
     - lua_processor@yuhao_chaifen_processor
@@ -86,7 +86,7 @@ engine:
     - table_translator
     - lua_translator@yuhao_helper # 幫助文檔
     - "table_translator@zaoci" # 用户造詞
-    - lua_translator@yuhao_switch_tr
+    - lua_translator@yuhao_switch_tr@yuhao_macro
   filters:
     - lua_filter@yuhao_single_char_only_for_full_code
     - lua_filter@yuhao_char_first
@@ -192,6 +192,36 @@ embeded_cands:
   next_format: "${候選}${Comment}${Seq}"             # 非首選的渲染格式
   separator: " "                                     # 候選之間的分隔符
 
+# 自定義宏
+yuhao_macro:
+  funckeys:
+    macro: [ 0x2f ] # 當輸入串以 "/" 開頭時, 認爲是宏調用
+  macros:
+    help:
+      - { type: tip, name: ❖配置中心 }
+      - { type: switch, name: embeded_cands, states: [ ☐嵌入, ☑嵌入 ] }
+      - { type: switch, name: yuhao_single_char_only_for_full_code, states: [ ☐字詞, ☑純單 ] }
+      - { type: radio, names: [ yuhao_chaifen.off, yuhao_chaifen.lv1, yuhao_chaifen.lv2, yuhao_chaifen.lv3 ], states: [ ☐☐☐註解, ☑☐☐註解, ☐☑☐註解, ☐☐☑註解 ] }
+      - { type: switch, name: traditionalization, states: [ ☐簡保持, ☑簡轉繁 ] }
+      - { type: switch, name: simplification, states: [ ☐繁保持, ☑繁轉簡 ] }
+    date:
+      - { type: eval, name: ☀日期, expr: return os.date("%Y-%m-%d") }
+      - { type: eval, name: ⛅年月日, expr: return os.date("%Y年%m月%d日") }
+    time:
+      - { type: eval, name: ⌚時間, expr: return os.date("%H:%M:%S") }
+      - { type: eval, name: Ⓣ時間, expr: return os.date("%Y%m%d%H%M") }
+      - { type: eval, name: Ⓢ時間戳, expr: return tostring(os.time()) }
+    char:
+      - { type: switch, name: yuhao_single_char_only_for_full_code, states: [ ☐字詞, ☑純單 ] }
+    div:
+      - { type: radio, names: [ yuhao_chaifen.off, yuhao_chaifen.lv1, yuhao_chaifen.lv2, yuhao_chaifen.lv3 ], states: [ ☐☐☐註解, ☑☐☐註解, ☐☑☐註解, ☐☐☑註解 ] }
+    embed:
+      - { type: switch, name: embeded_cands, states: [ ☐嵌入, ☑嵌入 ] }
+    trad:
+      - { type: switch, name: traditionalization, states: [ ☐不轉換, ☑簡轉繁 ] }
+    simp:
+      - { type: switch, name: simplification, states: [ ☐不轉換, ☑繁轉簡 ] }
+
 punctuator:
   import_preset: symbols
   half_shape:
@@ -238,6 +268,7 @@ recognizer:
     uppercase: "^(?![`;]).*[A-Z][-_+.'0-9A-Za-z]*$"
     reverse_lookup: "^z([a-z]+?)*$"
     zaoci: "^[a-y]*`[a-y`]*$"
+    macro: "^/[a-z]*$"
 
 style:
   horizontal: false


### PR DESCRIPTION
Implemented:

1. *tip*: a macro that can work as tips or quick phrases
2. *switch*: the macro that displays and toggles the switch states
3. *radio*: the macro that displays and toggles states of multi-selectable switches
4. *shell*: custom shell commands that work under unix like systems
5. *eval*: custom lua macro that works as a function or a functional object

中文:

1. *提示*: 作爲提示顯示在候選處, 可用於快捷短語或作爲其他宏的功能提示
2. *開關*: 可用於顯示輸入法的功能開關狀態, 並予以切換
3. *單選*: 同開關類似, 顯示開關狀態並在多個選項之間切換
4. *Shell*: 適用於 *Linux*/*Mac* 系統的命令宏, 可以執行預先配置的命令或脚本
5. *求值*: 提供 *lua* 擴展功能, 允許配置 *lua* 語句、函數或 *table* 對象