### PR TITLE
allow macros to hijack ascii keys, especially number keys

### DIFF
--- a/beta/schema/lua/yuhao/yuhao_switch.lua
+++ b/beta/schema/lua/yuhao/yuhao_switch.lua
@@ -364,8 +364,10 @@ local function parse_conf_macro_list(env)
                     local cmd = key_map:get_value("cmd"):get_string()
                     local name = key_map:has_key("name") and key_map:get_value("name"):get_string() or ""
                     local text = key_map:has_key("text") and key_map:get_value("text"):get_bool() or false
+                    local hijack = key_map:has_key("hijack") and key_map:get_value("hijack"):get_bool() or false
                     if #cmd ~= 0 and (#name ~= 0 or text) then
                         table.insert(cands, new_shell(name, cmd, text))
+                        cands.hijack = cands.hijack or hijack
                     end
                 end
             elseif type == macro_types.eval then
@@ -373,8 +375,10 @@ local function parse_conf_macro_list(env)
                 if key_map:has_key("expr") then
                     local name = key_map:has_key("name") and key_map:get_value("name"):get_string() or ""
                     local expr = key_map:get_value("expr"):get_string()
+                    local hijack = key_map:has_key("hijack") and key_map:get_value("hijack"):get_bool() or false
                     if #expr ~= 0 then
                         table.insert(cands, new_eval(name, expr))
+                        cands.hijack = cands.hijack or hijack
                     end
                 end
             end
@@ -424,9 +428,7 @@ end
 
 -- ######## PROCESSOR ########
 
-local function proc_handle_macros(env, ctx, input, idx)
-    local name, args = get_macro_args(input, namespaces:config(env).funckeys.macro)
-    local macro = namespaces:config(env).macros[name]
+local function proc_handle_macros(env, ctx, macro, args, idx)
     if macro then
         if macro[idx] then
             macro[idx]:trigger(env, ctx, args)
@@ -462,16 +464,18 @@ function yuhao_switch_proc.func(key_event, env)
     local funckeys = namespaces:config(env).funckeys
     if funckeys.macro[string.byte(string.sub(ctx.input, 1, 1))] then
         -- 當前輸入串以 funckeys/macro 定義的鍵集合開頭
-        local idx = select_index(key_event, env)
-        if idx >= 0 then
-            -- 選中宏候選
-            return proc_handle_macros(env, ctx, string.sub(ctx.input, 2), idx + 1)
-        elseif funckeys.macro[ch] then
-            -- 宏候選分隔符
-            ctx:push_input(string.char(ch))
-            return kAccepted
-        else
-            -- 假裝無事發生
+        local name, args = get_macro_args(string.sub(ctx.input, 2), namespaces:config(env).funckeys.macro)
+        local macro = namespaces:config(env).macros[name]
+        if macro then
+            if macro.hijack and ch > 0x20 and ch < 0x7f then
+                ctx:push_input(string.char(ch))
+                return kAccepted
+            else
+                local idx = select_index(key_event, env)
+                if idx >= 0 then
+                    return proc_handle_macros(env, ctx, macro, args, idx + 1)
+                end
+            end
             return kNoop
         end
     end

--- a/beta/schema/lua/yuhao/yuhao_switch.lua
+++ b/beta/schema/lua/yuhao/yuhao_switch.lua
@@ -212,11 +212,11 @@ local function new_shell(name, cmd, text)
         local fd = get_fd(args)
         if self.text then
             local t = fd:read('a')
+            fd:close()
             if #t ~= 0 then
                 env.engine:commit_text(t)
             end
         end
-        fd:close()
         ctx:clear()
     end
 

--- a/beta/schema/yuhao.custom.yaml
+++ b/beta/schema/yuhao.custom.yaml
@@ -24,6 +24,8 @@ patch:
   recognizer/patterns/+:
     # 配合自定義宏, 允許以下宏使用 / 鍵追加參數
     macros: "^/(calc|echo|len)(/[a-z]*)*$"
+    macro_calc: "^/calc(/[a-zA-Z0-9\\+\\-\\*\\^\\.%]*)*$"
+    macro_echo: "^/echo(/[a-zA-Z]*)*$"
   yuhao_macro/macros/+:
     # 自定義宏
     # 先为宏命名, 如 *mymacro*, 则將其添加到 *macros* 下,
@@ -106,23 +108,22 @@ patch:
       # m(mod) => %
       # a(remainder) => //
       - type: eval
+        hijack: true
         expr: >
           local nums = {q='1',w='2',e='3',r='4',t='5',y='6',u='7',i='8',o='9',p='0'}
           local signs = {h='*',j='-',k='+',l='/',s='^',d='.',m='%',x='*',a='//'}
-          setmetatable(signs, { __index = function() return "+" end })
+          setmetatable(signs, { __index = function(self, key) return key end })
           local t = {
             nums = nums,
             signs = signs,
           }
           function t:calc(args, peek_only)
             if #args == 0 then return "" end
+            local expr = table.concat(args, "/")
             local res = {}
-            for _, expr in ipairs(args) do
-              expr = string.gsub(string.gsub(expr, "[qwertyuiop]", self.nums), "[^0-9]+", self.signs)
-              local eval = load("return " .. expr)
-              table.insert(res, (peek_only and expr .. "=" or "") .. (eval and eval() or "?"))
-            end
-            return table.concat(res, ",")
+            expr = string.gsub(string.gsub(expr, "[qwertyuiop]", self.nums), "[^0-9%+%-*/^.%%]", self.signs)
+            local eval = load("return " .. expr)
+            return (peek_only and expr .. "=" or "") .. (eval and eval() or "?")
           end
           function t:peek(args)
             return self:calc(args, true)


### PR DESCRIPTION
- 自定義 *lua* 宏可以通過設置 `hijack: true` 以使該宏攔截 *ascii* 字符鍵, 特别是數字鍵, 卽可以將 `[0-9]`, `[+-*/]` 等字符輸入到宏參數中.
- 得益於此, 示例的計算器宏現可使用數字鍵和符號鍵, 以空格上屏結果.